### PR TITLE
Add Redis cache, refactor Caddyfile to read domain from environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ data/*
 
 # but this one which contains db credentials
 data/config/shimmie.conf.php
+
+shimmity.env

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Make sure you have [git](https://git-scm.com/) and a relatively up-to-date versi
 ### Setup
 To clone this repository, execute `git clone https://github.com/iSneeze/shimmitty` in your terminal of choice
 
-First you probably want to edit the `caddy/Caddyfile`, change the domain to match yours, no "http://", just the domain name. E.g. `example.com` or if using a subdomain e.g. `megaawesomebooru.mittydot.com`
+First, copy shimmitty.env.example to shimmity.env and change the domain to match yours, for production use just the domain name. E.g. `example.com` or if using a subdomain e.g. `megaawesomebooru.mittydot.com`. For local testing, you can instead use "http://127.0.0.1".
 
 After that, change into the newly downloaded folder by using `cd shimmitty` and execute `docker-compose up` from your terminal of choice to start shimmie with caddy. in this mode you will get logs in the terminal and see if something is failing. (to exit, press Ctrl + C)
 

--- a/README.md
+++ b/README.md
@@ -60,4 +60,9 @@ shimmie:
 ...
 ```
 
+To configure Shimmie to use the included Redis cache, edit data/config/shimmie.conf.php and include the following line at the end:
+```php
+define('CACHE_DSN', 'redis://redis:63790');
+```
+
 Happy testing!

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,5 +1,5 @@
 # Insert your domain here!
-your.domain.here {
+{$SHIMMITY_DOMAIN} {
     log {
         output file /data/log/access.log
     }

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,5 +21,10 @@ services:
     networks:
       - caddy
 
+  redis:
+    image: redis:alpine
+    networks:
+      - caddy
+
 networks:
   caddy:

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,6 +8,7 @@ services:
     ports:
       - 80:80
       - 443:443
+    env_file: shimmity.env
     networks:
       - caddy
 

--- a/shimmity.env.example
+++ b/shimmity.env.example
@@ -1,0 +1,1 @@
+SHIMMITY_DOMAIN="http://127.0.0.1"


### PR DESCRIPTION
- added Redis cache, update README with instructions to configure Shimmie to use it
- to avoid git merge conflicts in the future, I updated the Caddyfile to read the domain name from the environment and updated compose.yml to read env vars from a file. The env file is added to .gitignore, a example env file read to copy is included.