### PR TITLE
Switch from Redis to Memcached.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ shimmie:
 ...
 ```
 
-To configure Shimmie to use the included Redis cache, edit data/config/shimmie.conf.php and include the following line at the end:
+To configure Shimmie to use the included Memcached cache, edit data/config/shimmie.conf.php and include the following line at the end:
 ```php
-define('CACHE_DSN', 'redis://redis:6379');
+define('CACHE_DSN', 'memcache://memcached:11211');
 ```
 
 Happy testing!

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,8 +21,12 @@ services:
     networks:
       - caddy
 
-  redis:
-    image: redis:alpine
+  memcached:
+    image: memcached:alpine
+    command:
+      - --conn-limit=1024
+      - --memory-limit=64
+      - --threads=4
     networks:
       - caddy
 


### PR DESCRIPTION
If you want to test Memcached instead of Redis, here is the config.

Shimmie does not seem to throw any errors if it can't connect to Memcached, to check if it actually writes stuff to Memcached try
```bash
echo "stats items" | nc 127.0.0.1:11211
```
inside the Memcached container.