### PR TITLE
Proposal: move our config changes to custom file and include it

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,10 @@ shimmie:
 ...
 ```
 
-To configure Shimmie to use the included Memcached cache, edit data/config/shimmie.conf.php and include the following line at the end:
+Our modifications to Shimmie's default config are stored in data/config/custom.conf.php and automatically mounted into the Docker container.
+To ensure they are actually loaded, add the following line to data/config/shimmie.conf.php
 ```php
-define('CACHE_DSN', 'memcache://memcached:11211');
+@include_once "data/config/custom.conf.php";
 ```
 
 Happy testing!

--- a/data/config/custom.conf.php
+++ b/data/config/custom.conf.php
@@ -1,0 +1,7 @@
+<?php
+
+// use local memcached
+define('CACHE_DSN', 'memcache://memcached:11211');
+
+// trust X-FORWARDED-FOR Headers from Caddy so Shimmie can see the user's real IP
+define("TRUSTED_PROXIES", [ '192.168.0.0/16', '172.16.0.0/12', '10.0.0.0/8', ]);


### PR DESCRIPTION
To make modifications to Shimmie's default config easier, we could move our changes to a custom file and include it from shimmie.conf.php - then future updates can be executed with a simple git pull.

I've also added all private IP ranges as TRUSTED_PROXIES so Shimmie trusts Caddy's X-FORWARDED-FOR Header - otherwise stuff like IP bans wont' work.