### PR TITLE
Fix bugs in upload block

### DIFF
--- a/themes/mitty/script.js
+++ b/themes/mitty/script.js
@@ -66,15 +66,20 @@ box.addEventListener('dragover', e => {
 
 });
 
-box.addEventListener('drop', e => {
-    e.preventDefault();
-
-    fileInput.files = e.dataTransfer.files;
+function updateText(e) {
     const newText = fileInput.files.length > 1 ? `${fileInput.files.length} files selected` : `${fileInput.files[0].name}`;
     dropText.textContent = `${newText} - `;
     dropText.title = newText;
     browseLink.textContent = 'change';
+}
+box.addEventListener('drop', e => {
+    e.preventDefault();
+
+    fileInput.files = e.dataTransfer.files;
+    updateText();
     dragEnd();
 });
 
 box.addEventListener('dragleave', dragHoverEnd);
+
+fileInput.addEventListener('change', updateText);

--- a/themes/mitty/script.js
+++ b/themes/mitty/script.js
@@ -8,7 +8,7 @@ const dropHint = dropHintTemplate.content.cloneNode(true).firstElementChild;
 const dropText = dropHint.querySelector('.drop-text');
 const browseLink = dropHint.querySelector('.browse-link');
 
-fileInput.hidden = true;
+fileInput.classList.add('visually-hidden');
 fileInput.after(dropHint);
 
 function hasFiles(e) {

--- a/themes/mitty/style.css
+++ b/themes/mitty/style.css
@@ -20,6 +20,10 @@
     position: relative;
 }
 
+.autocomplete_completions {
+    position: fixed;
+}
+
 .upload-more-link {
     font-size: 11px;
     display: block;

--- a/themes/mitty/style.css
+++ b/themes/mitty/style.css
@@ -16,6 +16,17 @@
     color: var(--text-color);
 }
 
+.visually-hidden {
+    position: absolute;
+    width: 1px; height: 1px;
+    padding: 0; margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+}
+
 .mini_upload {
     position: relative;
 }
@@ -45,6 +56,11 @@
         background: #3a5a9a;
         border-color: var(--link-color);
     }
+}
+
+#data\[\]:focus + .drop-hint {
+    outline: 1px solid  var(--link-color);
+    outline-offset: 1px;
 }
 
 .drop-text {

--- a/themes/mitty/upload.theme.php
+++ b/themes/mitty/upload.theme.php
@@ -67,7 +67,6 @@ class MittyUploadTheme extends UploadTheme
                 $max_total_size > 0 ? "Total limit $max_total_kb" : null,
                 ")",
             ),
-            HR(),
             A(["href" => make_link("upload"), "class" => "upload-more-link"], "Upload multiple files »"),
 
         );


### PR DESCRIPTION
Fixes some of the bugs and mistakes with the upload block.

- Autocomplete for tags was positioned offscreen. It's now visible where it's supposed to be.
- Updates the text when selected through the file picker.
- You can now tab to and upload using only the keyboard.

Also bye bye to the horizontal line. Took up space and didn't really fit what the rest of the theme did.
<img width="239" height="229" alt="image" src="https://github.com/user-attachments/assets/e2e4f278-315e-417b-90f1-93f8224dc179" />
<img width="237" height="206" alt="image" src="https://github.com/user-attachments/assets/33850017-4ceb-49f1-b0da-d6d2743d14fb" />